### PR TITLE
Double api call

### DIFF
--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -22,7 +22,6 @@ class App extends Component {
     this.setState({favoriteWords:copyOfState})
   }
   displayWord = (word) =>{
-    console.log(word)
     this.setState({currentWord:word})
   }
   addWord = (word) =>{

--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -22,6 +22,7 @@ class App extends Component {
     this.setState({favoriteWords:copyOfState})
   }
   displayWord = (word) =>{
+    console.log(word)
     this.setState({currentWord:word})
   }
   addWord = (word) =>{

--- a/src/App/App.jsx
+++ b/src/App/App.jsx
@@ -26,10 +26,8 @@ class App extends Component {
     this.setState({currentWord:word})
   }
   addWord = (word) =>{
-    console.log(word)
    let wordDuplicate = this.state.favoriteWords.find(favWord =>{
-     console.log(favWord.shortdef[0] === word.hwi.hw)
-      if(favWord.meta.id === word.meta.id || favWord.shortdef[0] === word.hwi.hw){
+      if(favWord.es.meta.id === word.es.meta.id || favWord.es.shortdef[0] === word.en.hwi.hw){
         return true
       } 
       return undefined

--- a/src/DefinitionCard/DefinitionCard.js
+++ b/src/DefinitionCard/DefinitionCard.js
@@ -4,26 +4,14 @@ import './DefinitionCard.css'
 function DefinitionCard (props){
   return (
     <section className = 'word-card card-direction'>
-         {props.word.meta.lang === 'es' && 
-          <> 
+      
           <section className = "span-word">
-            {props.word.hwi.hw}
+            {props.word.es.hwi.hw}
             </section> 
             <section className = "definition">
-            {props.word.shortdef[0]}
+            {props.word.en.hwi.hw}
             </section>
-          </>
-        }
-        {props.word.meta.lang === 'en' && 
-        <>
-          <section className = "span-word">
-         {props.word.shortdef[0]}
-            </section>
-            <section className = "definition">
-          {props.word.hwi.hw}
-            </section>
-        </>
-      }
+          
       <button className = 'addButton' onClick = {() =>{
         props.addWord(props.word)
       }}>

--- a/src/NavBar/NavBar.jsx
+++ b/src/NavBar/NavBar.jsx
@@ -6,8 +6,8 @@ function NavBar() {
   return (
     <section className="nav-container">
       <img src ={logo} alt= 'Learnlo logo' className = 'logo'/>
-      <NavLink className="link" to="/myWords">My Words</NavLink>
       <NavLink className="link" to="/">Home</NavLink>
+      <NavLink className="link" to="/myWords">My Words</NavLink>
       <NavLink className="link" to="/quiz">Quiz </NavLink>
     </section>
   );

--- a/src/Word/Word.jsx
+++ b/src/Word/Word.jsx
@@ -52,6 +52,18 @@ function Word(props) {
             Definition: {props.currentWord.en.hwi.hw}
             {enAudio}
           </p>
+        
+            
+            {/* {props.currentWord.en.def[0].sseq[0][0][1].dt[1][1][0]
+            &&
+            <p className = 'definition'>
+            Example Sentance: {props.currentWord.en.def[0].sseq[0][0][1].dt[1][1][0].t}
+            {props.currentWord.en.def[0].sseq[0][0][1].dt[1][1][0].tr}
+           </p> */}
+            } 
+            
+            
+          
 
       <button
         role = "delete-button"

--- a/src/Word/Word.jsx
+++ b/src/Word/Word.jsx
@@ -7,48 +7,52 @@ function Word(props) {
   if (!props.currentWord) {
     return <h1 role = 'no-word-error'className="center">Add a word!</h1>;
   }
-  let audio;
-  if (props.currentWord.hwi.prs) {
-    console.log(props.currentWord)
-    let lang = props.currentWord.meta.lang
-    if(props.currentWord.hwi.prs[0].sound === undefined){
-      audio = ''
+  let esAudio;
+  let enAudio;
+
+  if (props.currentWord.es.hwi.prs) {
+  
+    if(props.currentWord.es.hwi.prs[0].sound === undefined){
+      esAudio = ''
     }else{
-      const audioFile = props.currentWord.hwi.prs[0].sound.audio;
-    const audioSubDirect = audioFile.charAt(0);
-    audio = (
+      const esAudioFile = props.currentWord.es.hwi.prs[0].sound.audio;
+    const esAudioSubDirect = esAudioFile.charAt(0);
+    esAudio = (
       <audio className='audio' controls >
-        < source role = 'audio' src={`https://media.merriam-webster.com/audio/prons/${lang}/me/mp3/${audioSubDirect}/${audioFile}.mp3`} />
+        < source role = 'audio' src={`https://media.merriam-webster.com/audio/prons/es/me/mp3/${esAudioSubDirect}/${esAudioFile}.mp3`} />
       </audio>
     );
+    }
+  }
+   console.log(props.currentWord.en.hwi.prs[0])
+    if (props.currentWord.en.hwi.prs) {
+    
+      if(props.currentWord.en.hwi.prs[0].sound === undefined){
+        enAudio = ''
+      }else{
+        const enAudioFile = props.currentWord.en.hwi.prs[0].sound.audio;
+      const enAudioSubDirect = enAudioFile.charAt(0);
+      enAudio = (
+        <audio className='audio' controls >
+          < source role = 'audio' src={`https://media.merriam-webster.com/audio/prons/en/us/mp3/${enAudioSubDirect}/${enAudioFile}.mp3`} />
+        </audio>
+      );
     }
     
   }
   return (
     <section role = 'word' className="word-card">
-      {props.currentWord.meta.lang === 'es' && 
-        <>
+     
         <p className = 'span-word'>
-          {props.currentWord.hwi.hw}
-          {audio}
+          {props.currentWord.es.hwi.hw}
+          {esAudio}
           </p>
 
           <p className = 'definition'>
-            Definition: {props.currentWord.shortdef[0]}
-          </p>
-        </>
-          }
-      {props.currentWord.meta.lang === 'en' && 
-        <>
-        <p className = 'span-word'>
-        {props.currentWord.shortdef[0]}
+            Definition: {props.currentWord.en.hwi.hw}
+            {enAudio}
           </p>
 
-          <p className = 'definition'>
-          Definition: {props.currentWord.hwi.hw}
-          </p>
-        </>
-      }
       <button
         role = "delete-button"
         type="button"

--- a/src/fetchCalls/fetchCalls.js
+++ b/src/fetchCalls/fetchCalls.js
@@ -1,5 +1,28 @@
+import { object } from "prop-types"
+
 export const getWord = async (word) =>{
   let response = await fetch(`https://www.dictionaryapi.com/api/v3/references/spanish/json/${word}?key=${process.env.REACT_APP_API_KEY}`)
   let definition = await response.json()
+  if(typeof definition[0] !== object){
+    return "Sorry we can't find that word"
+  }
+  let lang = definition[0].meta.lang
+  let nextCal  = definition[0].def[0].sseq[0][0][1].dt[0][1]
+  let pipeIndex = nextCal.indexOf('|')
+  let endCurlyIndex;
+  for(let i = pipeIndex; i<nextCal.length; i++){
+    if(nextCal.charAt(i) === '}'){
+      endCurlyIndex = i
+      break
+    }
+  }
+  let nextQueryWord = nextCal.slice(pipeIndex+1,endCurlyIndex)
+  let secondResponse = await fetch(`https://www.dictionaryapi.com/api/v3/references/spanish/json/${nextQueryWord}?key=${process.env.REACT_APP_API_KEY}`)
+  let secondDefinition = secondResponse.json()
+  let secondLang = secondDefinition[0].meta.lang
+  let words = {
+    [lang] : definition[0],
+    [secondLang] : secondDefinition[0]
+  }
 return definition[0]
 }

--- a/src/fetchCalls/fetchCalls.js
+++ b/src/fetchCalls/fetchCalls.js
@@ -22,13 +22,14 @@ export const getWord = async (word) =>{
   let secondResponse = await fetch(`https://www.dictionaryapi.com/api/v3/references/spanish/json/${nextQueryWord}?key=${process.env.REACT_APP_API_KEY}`)
   let secondDefinition = await secondResponse.json()
   console.log(secondDefinition)
-  if(typeof secondDefinition[0] !== "object" || Array.isArray(secondDefinition[0])){
+  if(typeof secondDefinition[0] !== "object"){
     return "Sorry we can't find that word"
   }
-  let secondLang = secondDefinition[0]
   if(secondDefinition[0].meta.lang === lang  ){
     return "Sorry we can't find that word"
   }
+  let secondLang = secondDefinition[0].meta.lang
+
   let words = {
     [lang] : definition[0],
     [secondLang] : secondDefinition[0]

--- a/src/fetchCalls/fetchCalls.js
+++ b/src/fetchCalls/fetchCalls.js
@@ -3,7 +3,7 @@ import { object } from "prop-types"
 export const getWord = async (word) =>{
   let response = await fetch(`https://www.dictionaryapi.com/api/v3/references/spanish/json/${word}?key=${process.env.REACT_APP_API_KEY}`)
   let definition = await response.json()
-  if(typeof definition[0] !== object){
+  if(typeof definition[0] !== "object"){
     return "Sorry we can't find that word"
   }
   let lang = definition[0].meta.lang
@@ -18,11 +18,14 @@ export const getWord = async (word) =>{
   }
   let nextQueryWord = nextCal.slice(pipeIndex+1,endCurlyIndex)
   let secondResponse = await fetch(`https://www.dictionaryapi.com/api/v3/references/spanish/json/${nextQueryWord}?key=${process.env.REACT_APP_API_KEY}`)
-  let secondDefinition = secondResponse.json()
+  let secondDefinition = await secondResponse.json()
+  if(typeof secondDefinition[0] !== "object"){
+    return "Sorry we can't find that word"
+  }
   let secondLang = secondDefinition[0].meta.lang
   let words = {
     [lang] : definition[0],
     [secondLang] : secondDefinition[0]
   }
-return definition[0]
+return words
 }

--- a/src/fetchCalls/fetchCalls.js
+++ b/src/fetchCalls/fetchCalls.js
@@ -7,6 +7,7 @@ export const getWord = async (word) =>{
     return "Sorry we can't find that word"
   }
   let lang = definition[0].meta.lang
+  console.log(lang)
   let nextCal  = definition[0].def[0].sseq[0][0][1].dt[0][1]
   let pipeIndex = nextCal.indexOf('|')
   let endCurlyIndex;
@@ -17,12 +18,17 @@ export const getWord = async (word) =>{
     }
   }
   let nextQueryWord = nextCal.slice(pipeIndex+1,endCurlyIndex)
+  console.log(nextQueryWord)
   let secondResponse = await fetch(`https://www.dictionaryapi.com/api/v3/references/spanish/json/${nextQueryWord}?key=${process.env.REACT_APP_API_KEY}`)
   let secondDefinition = await secondResponse.json()
-  if(typeof secondDefinition[0] !== "object"){
+  console.log(secondDefinition)
+  if(typeof secondDefinition[0] !== "object" || Array.isArray(secondDefinition[0])){
     return "Sorry we can't find that word"
   }
-  let secondLang = secondDefinition[0].meta.lang
+  let secondLang = secondDefinition[0]
+  if(secondDefinition[0].meta.lang === lang  ){
+    return "Sorry we can't find that word"
+  }
   let words = {
     [lang] : definition[0],
     [secondLang] : secondDefinition[0]


### PR DESCRIPTION
This PR updates the fetch request to call the api twice, once for the initial word and once to get the translation of that word. This gives access to both pronunciations and makes showing the data cleaner. This PR also displays the data using the fetch return object and displays the pronunciation for both words if it is available. 
closes #68 